### PR TITLE
Add README, license, and env examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Amit Kumar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Cogniwide AI Demo – Voice & Chat PoCs
+
+Proof-of-concept repository showcasing two independent AI customer-support systems:
+
+| Folder | PoC | Stack Highlights |
+|--------|-----|------------------|
+| `cogniwide_task1` | **AI Voice Agent System** | FastAPI · Twilio Voice / Vapi · Whisper / ElevenLabs · PostgreSQL |
+| `cogniwide_task2` | **AI Multi-Agent Chat Support System** | FastAPI · OpenAI GPT-4o-mini · Vector search · SendGrid / WhatsApp · PostgreSQL |
+
+## Repo layout
+
+````
+.
+├── cogniwide_task1/      # PoC-1 voice assistant
+├── cogniwide_task2/      # PoC-2 chat assistant
+├── README.md             # <— you are here
+└── LICENSE               # MIT
+````
+
+## Quick start (Docker)
+```bash
+# clone & cd
+git clone https://github.com/amitskidrow/ss_cogniwide.git
+cd ss_cogniwide
+
+# PoC-1
+cp cogniwide_task1/.env.example cogniwide_task1/.env
+docker compose -f cogniwide_task1/docker-compose.yml up --build
+
+# PoC-2
+cp cogniwide_task2/.env.example cogniwide_task2/.env
+docker compose -f cogniwide_task2/docker-compose.yml up --build
+```
+
+## Documentation
+
+* **PoC-1 details →** [`cogniwide_task1/README.md`](cogniwide_task1/README.md)
+* **PoC-2 details →** [`cogniwide_task2/README.md`](cogniwide_task2/README.md)
+
+---
+
+© 2025 Amit Kumar – MIT License
+

--- a/cogniwide_task1/.env.example
+++ b/cogniwide_task1/.env.example
@@ -1,0 +1,14 @@
+# === AI keys ===
+OPENAI_API_KEY=
+ELEVENLABS_API_KEY=
+
+# === Twilio ===
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
+
+# === Database ===
+POSTGRES_URL=postgresql://user:pass@db:5432/poc1
+
+# === Optional ===
+LOG_LEVEL=info

--- a/cogniwide_task2/.env.example
+++ b/cogniwide_task2/.env.example
@@ -1,0 +1,15 @@
+# === AI keys ===
+OPENAI_API_KEY=
+
+# === Email / WhatsApp ===
+SENDGRID_API_KEY=
+WHATSAPP_TOKEN=
+
+# === Database ===
+POSTGRES_URL=postgresql://user:pass@db:5432/poc2
+
+# === Vector DB (local path) ===
+VECTOR_DB_PATH=./vector_store
+
+# === Optional ===
+LOG_LEVEL=info

--- a/cogniwide_task2/README.md
+++ b/cogniwide_task2/README.md
@@ -1,29 +1,46 @@
-# AI Multi-Agent Chat Support System (PoC-2)
+# PoC-2 — AI Multi-Agent Chat Support System
 
-Proof-of-concept chat platform orchestrating multiple AI agents (intent classifier, router, FAQ, ticketing, account, notification).
+## 1. Overview
+Chat platform that chains specialised AI agents (Intent, FAQ, Ticket, Account, Notify) to resolve support queries autonomously.
 
-## Requirements
-- Docker & Docker Compose
-
-## Quickstart
-```bash
-# Build and launch services
-docker-compose up --build
-
-# In a new terminal, send a test chat message:
-curl -X POST http://localhost:8000/chat/message \
-  -H "X-API-KEY: your_api_key_here" \
-  -H "Content-Type: application/json" \
-  -d '{"user_id":"user123","text":"Hello, I need help","locale":"en"}'
+## 2. Architecture
+```mermaid
+flowchart TD
+    U[User / Browser] -->|POST /chat/message| A[FastAPI<br>Gateway]
+    A --> B(Intent Classifier)
+    B --> C(Routing Agent)
+    C -->|FAQ| D(FAQ Agent)
+    C -->|Ticket| E(Ticket Agent)
+    C -->|Account| F(Account Agent)
+    C -->|Fallback| G(Live-Agent Sim)
+    E --> H(Notify Agent)
+    D & E & F --> I[PostgreSQL]
 ```
 
-## Endpoints
-- `POST /chat/message`
-- `GET /session/{id}`
-- `GET /ticket/{id}`
-- `POST /notify/test`
-- `GET /health`
-- `DELETE /session/{id}`
-- `/metrics` (Prometheus)
+## 3. Setup
 
-For full details see [PRD.md](PRD.md).
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+## 4. API
+
+| Method | Path            | Purpose           |
+| ------ | --------------- | ----------------- |
+| POST   | `/chat/message` | Ingest chat       |
+| GET    | `/session/{id}` | Full conversation |
+| GET    | `/ticket/{id}`  | Ticket status     |
+
+## 5. Environment Variables (`.env.example`)
+
+Includes `OPENAI_API_KEY`, `POSTGRES_URL`, `SENDGRID_API_KEY`, `WHATSAPP_TOKEN`, `VECTOR_DB_PATH`.
+
+## 6. Testing
+
+`pytest -q` for agent unit tests.
+
+## 7. License
+
+MIT – see repository root.
+


### PR DESCRIPTION
## Summary
- add top-level README and MIT license
- document PoC-1 voice agent system
- document PoC-2 multi-agent chat support system
- include `.env.example` files for both PoCs

## Testing
- `git status --short`
- `git log -1 --stat`
- `git remote -v` *(fails: no remote)*


------
https://chatgpt.com/codex/tasks/task_e_6852b5a57144832cb3fab95f0a21a8ff